### PR TITLE
Removes the contextual help section. Fixes a fatal error.

### DIFF
--- a/classes/class-woo-sidebars.php
+++ b/classes/class-woo-sidebars.php
@@ -46,7 +46,6 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  * - add_post_column_data()
  * - enable_custom_post_sidebars()
  * - multidimensional_search()
- * - add_contextual_help()
  *
  * - load_localisation()
  * - activation()
@@ -107,7 +106,6 @@ class Woo_Sidebars {
 			global $pagenow;
 
 			add_action( 'admin_print_styles', array( $this, 'enqueue_styles' ), 12 );
-			add_action( 'admin_head', array( $this, 'add_contextual_help' ) );
 			if ( $pagenow == 'edit.php' && isset( $_GET['post_type'] ) && esc_attr( $_GET['post_type'] ) == $this->token ) {
 				add_filter( 'manage_edit-' . $this->token . '_columns', array( $this, 'register_custom_column_headings' ), 10, 1 );
 				add_action( 'manage_posts_custom_column', array( $this, 'register_custom_columns' ), 10, 2 );
@@ -743,44 +741,6 @@ class Woo_Sidebars {
 
         return false;
 	} // End multidimensional_search()
-
-	/**
-	 * add_contextual_help function.
-	 *
-	 * @description Add contextual help to the current screen.
-	 * @access public
-	 * @since 1.0.0
-	 * @return void
-	 */
-	public function add_contextual_help () {
-		if ( empty( get_current_screen() ) || get_current_screen()->id != 'edit-sidebar' ) { return; }
-
-		get_current_screen()->add_help_tab( array(
-		'id'		=> 'overview',
-		'title'		=> __( 'Overview', 'woosidebars' ),
-		'content'	=>
-			'<p>' . __( 'All custom widget areas are listed on this screen. To add a new customised widget area, click the "Add New" button.', 'woosidebars' ) . '</p>'
-		) );
-		get_current_screen()->add_help_tab( array(
-		'id'		=> 'wooframework-sbm',
-		'title'		=> __( 'Sidebar Manager', 'woosidebars' ),
-		'content'	=>
-			'<p>' . __( 'WooSidebars is intended to replace the Sidebar Manager found in the WooFramework. Please ensure that all sidebars have been transferred over from the Sidebar Manager, if you choose to use WooSidebars instead.', 'woosidebars' ) . '</p>' .
-			'<p>' . __( 'To transfer a sidebar from the Sidebar Manager:', 'woosidebars' ) . '</p>' .
-			'<ul>' . "\n" .
-			'<li>' . __( 'Create a new custom widget area in WooSidebars.', 'woosidebars' ) . '</li>' . "\n" .
-			'<li>' . sprintf( __( 'Visit the %sAppearance &rarr; Widgets%s screen and drag the widgets from the old sidebar into the newly created sidebar.', 'woosidebars' ), '<a href="' . esc_url( admin_url( 'widgets.php' ) ) . '">', '</a>' ) . '</li>' . "\n" .
-			'<li>' . __( 'Repeat this process for each of your custom sidebars, including dependencies if necessary (the WooSidebars conditions system replaces the need for dependencies).', 'woosidebars' ) . '</li>' . "\n" .
-			'<li>' . __( 'Once you are certain that you widgets have been moved across for all widget areas, remove the sidebar from the Sidebar Manager (don\'t forget to transfer any dependencies over as well, if necessary).', 'woosidebars' ) . '</li>' . "\n" .
-			'</ul>' . "\n"
-		) );
-
-		get_current_screen()->set_help_sidebar(
-		'<p><strong>' . __( 'For more information:', 'woosidebars' ) . '</strong></p>' .
-		'<p><a href="http://support.woothemes.com/?ref=' . 'woosidebars' . '" target="_blank">' . __( 'Support HelpDesk', 'woosidebars' ) . '</a></p>' .
-		'<p><a href="http://docs.woothemes.com/document/woosidebars/?ref=' . 'woosidebars' . '" target="_blank">' . __( 'WooSidebars Documentation', 'woosidebars' ) . '</a></p>'
-		);
-	} // End add_contextual_help()
 
 	/**
 	 * load_localisation function.


### PR DESCRIPTION
The contextual help tab caused a fatal error in version 1.4.4. While inspecting this, the contextual help is actually no longer relevant to most users, as it speaks largely to the Sidebar Manager in the WooFramework, which isn't relevant anymore either.

This PR removes the contextual help.