### PR TITLE
update wordpress.org contributor list, sync readme with wordpress.org

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === WooSidebars ===
-Contributors: woothemes, Automattic, mattyza
+Contributors: woocommerce, Automattic, woothemes, mattyza
 Tags: widgets, sidebars, widget-areas
 Requires at least: 4.1
-Tested up to: 4.6.5
+Tested up to: 4.9.6
 Stable tag: 1.4.5
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -29,7 +29,7 @@ Looking to contribute code to this plugin? [Fork the repository over at GitHub](
 
 Automatic installation is the easiest option as WordPress handles the file transfers itself and you don’t even need to leave your web browser. To do an automatic install of WooSidebars, log in to your WordPress admin panel, navigate to the Plugins menu and click Add New.
 
-In the search field type "WooSidebars" and click Search Plugins. Once you’ve found our widget areas plugin you can view details about it such as the point release, rating and description. Most importantly of course, you can install it by simply clicking Install Now. After clicking that link you will be asked if you’re sure you want to install the plugin. Click yes and WordPress will automatically complete the installation.
+In the search field type "WooSidebars" and click Search Plugins. Once you’ve found our widget areas plugin you can view details about it such as the the point release, rating and description. Most importantly of course, you can install it by simply clicking Install Now. After clicking that link you will be asked if you’re sure you want to install the plugin. Click yes and WordPress will automatically complete the installation.
 
 = Manual installation =
 


### PR DESCRIPTION
This PR updates the WordPress.org `readme.txt` to make `woocommerce the `Developer` of the plugin.

ref: p1596823265254600-sl